### PR TITLE
Test that -l and -o options are cumulative

### DIFF
--- a/test/getparams.bats
+++ b/test/getparams.bats
@@ -343,4 +343,21 @@ print_result() {
   [ "${output}" = "-a -b -- '--foo' '-c'" ]
 }
 
+@test "'--shortopts' is cumulative (0)" {
+  run "${BIN_GETPARAMS}" --shortopts=ab --shortopts=cd -- -a -b -c -d
+
+  print_result "${status}" "${output}"
+  [ "${status}" -eq 0 ]
+  [ "${output}" = "-a -b -c -d -- " ]
+}
+
+@test "'--longopts' is cumulative (0)" {
+  run "${BIN_GETPARAMS}" --longopts=foo,bar --longopts=fizz,buzz -- \
+    --foo --bar --fizz --buzz
+
+  print_result "${status}" "${output}"
+  [ "${status}" -eq 0 ]
+  [ "${output}" = "--foo --bar --fizz --buzz -- " ]
+}
+
 # vim: expandtab:ts=2:sw=0


### PR DESCRIPTION
Add tests to `getparams.bats` to verify that the `--longopts` and
`--shortopts` options can be specified multiple times and that the
arguments are accumulated.